### PR TITLE
Translate into Japanese

### DIFF
--- a/weeklypedia/issue_templates/strings/en_strings.yaml
+++ b/weeklypedia/issue_templates/strings/en_strings.yaml
@@ -10,108 +10,101 @@
 #------------------------------------------------------------------------------
 
 head_title: >-
-    the WEEKLYPEDIA ({full_lang_name}, Issue {issue_number})
+    the WEEKLYPEDIA ({full_lang_name}, 発行の番号 {issue_number})
 
 body_title: >-
     <em>the</em> WEEKLYPEDIA
 
 description: >- 
-    A list of the most edited Wikipedia articles and
-    discussions from the last week.  
+    先週から最も編集されたウィキペディアの記事とディスカッションのリストです。
 
-delivery_description: Delivered every Friday by email.
+delivery_description: 毎週金曜日にメールで送信されます。
 home_link: Home 
 archive_link: "{local.full_lang_name} edition archives"
-issue_label: Issue {issue_number}, {local.date} 
+issue_label: 発行の番号 {issue_number}, {local.date} 
 language_label: ({local.full_lang_name} Wikipedia edition) 
 intro: >-
-    Hello there! Welcome to our weekly digest of Wikipedia activity.
+    こんにちは！ウィキペディアの活動の毎週のダイジェストへようこそ。
 
 #-----------
 # Article section
 #------------------------------------------------------------------------------
 
-articles_heading: Articles
+articles_heading: 記事
 articles_summary: >-
-    This week, {total_users|ci} authors made {edits|ci} changes to
-    {titles|ci} different articles.
+    今週、{total_users|ci}人の著者が{titles|ci}の異なる記事に{edits|ci}の変更を加えました。
 
-articles_intro: The top 20 articles for the week
+articles_intro: 今週のトップ20の記事
 
-diff_count: "{edits|ci} changes"
-diff_author_count: by {users} authors
+diff_count: "{edits|ci}つの変更"
+diff_author_count: {users}人の著者による
 
 #-----------
 # New articles section
 #------------------------------------------------------------------------------
 
-new_articles_heading: New Articles
+new_articles_heading: 新しい記事
 # new_articles_summary: # TODO
 new_articles_intro: >-
-    The ten most actively edited articles created within the last week
+    先週作成された最も活発に編集された10の記事
 
 #-----------
 # Discussion section
 #------------------------------------------------------------------------------
 
-discussions_heading: Discussions
+discussions_heading: 話し合い
 # discussions_summary: # TODO
-discussions_intro: The most active discussions
+discussions_intro: 最も活発な話し合い
 
 #-----------
 # Stats section
 #------------------------------------------------------------------------------
 
-stats_heading: Stats
-stats_intro: A few numbers from last week
+stats_heading: 統計
+stats_intro: 先週のいくつかの統計
 user_edit_counts: >- 
-    {stats.users|ci} registered users and
-    {stats.anon_ip_count|ci} unregistered users made {stats.edits|ci}
-    edits to {stats.titles|ci} articles
+    {stats.users|ci}人の登録ユーザーと{stats.anon_ip_count|ci}人の未登録ユーザーが、{stats.titles|ci}件の記事を{stats.edits|ci}回編集しました。
 
 anon_edit_counts: >-
-    Unregistered users made {stats.anon_edits|ci} edits to
-    {stats.anon_titles|ci} articles
+    未登録のユーザーが{stats.anon_titles|ci}件の記事を{stats.anon_edits|ci}回編集しました。
 
 
 bot_edit_counts: >- 
-    {stats.bot_count|ci} robots made
-    {stats.bot_edits|ci} edits to {stats.bot_titles|ci} articles
+    {stats.bot_count|ci}つのボットが{stats.bot_titles|ci}の記事を{stats.bot_edits|ci}回編集しました
 
 #-----------
 # subscription invitation
 #------------------------------------------------------------------------------
 
-signup: Sign up
+signup: 登録
 pitch: >-
-    If you want to stay up to date with the most active articles and
-    discussions, please sign up for future issues.
+    最も活発な記事やディスカッションの最新情報を入手したい場合は、今後の発行に登録してください。
 
-email: "Email:"
-subscribe: Subscribe
+email: "電子メールアドレス:"
+subscribe: 登録します
 
 #-----------
 # Bottom section
 #------------------------------------------------------------------------------
 
-about_heading: About
+about_heading: Weeklypedia
+    Digestについて
 about_text: >-
-    This project retrieves a list of the week's recent changes using <a
-    href="http://tools.wmflabs.org/">Wikimedia Tool Labs</a>, and
-    delivers emails using Sendy. Code and more information <a
-    href="https://github.com/hatnote/weeklypedia">available on
-    GitHub</a>. Built by <a href="https://github.com/slaporte">Stephen
-    LaPorte</a> and <a href="https://github.com/mahmoud">Mahmoud
-    Hashemi</a>.
+    このプロジェクトは、<a
+    href="http://tools.wmflabs.org/">ウィキメディアツールラボ</a>を使用してその週の最近の変更のリストを取得し、Sendyを使用して電子メールを配信します。
+    コードと詳細については、<a
+    href="https://github.com/hatnote/weeklypedia">GitHubをご覧ください</a>。
+    <a href="https://github.com/slaporte">Stephen
+    LaPorte</a>と<a href="https://github.com/mahmoud">Mahmoud
+    Hashemi</a>によって建てられました。
 
-blog_link: Learn more on the Hatnote blog
+blog_link: Hatnoteブログで詳細をご覧ください。
 learn_more: >-
-    Learn more about the <a href="http://weekly.hatnote.com">Weeklypedia
-    Digest</a>!
+    <a href="http://weekly.hatnote.com">ウィークリーペディアダイジェストの詳細をご覧ください</a>。
 
 #-----------
 # Email footer
 #------------------------------------------------------------------------------
 
-sent_to: This email was sent to
-unsubscribe: unsubscribe from this list
+sent_to: このメールは[INSERT NAME HERE]に送信されました
+unsubscribe: このメール登録を解除します


### PR DESCRIPTION
### Info
These proposed changes are a translation from English into Japanese and specifically resolve #28. I have done my best to translate the text as faithfully as possible while still making it "Japanese" enough to not sound foreign. It is difficult to translate some informal sentences, such as "a few numbers[...]", etc but I have done my best to convey the general tone.

### Issues
1. At the bottom, there is a field labelled, "sent_to". I'm not sure where the persons email would normally go but I have pointed out that in order fot it to sound natural in Japanese, their name or email should go in the middle of the sentence. See [INSERT NAME HERE] on line 109. **Please do not merge without first fixing this.**
1. I am not aware of a good way to translate "unsubscribe". My Japanese dictionary was not very useful in this case and Google Translate gave me a very weird suggestion. I tried googling some Japanese newsletters but it seems they tend not to include unsubscribe links so I have done my best "good-faith" translation.  Perhaps another Japanese speaker could have a look and give a second opinion?

### Notes
I translated this file section by section without having an idea of what the actual newsletter will look like. If my edits break anything, please let me know and I'll fix it.

:)